### PR TITLE
Fix inaccessible assessment and pages

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
+import LoadingSpinner from '../LoadingSpinner';
 import { 
   LayoutDashboard,
   Shield,

--- a/src/pages/assessment/CmmcAssessmentStart.tsx
+++ b/src/pages/assessment/CmmcAssessmentStart.tsx
@@ -8,7 +8,8 @@ import {
   Users, 
   Target, 
   Clock,
-  Info
+  Info,
+  FileCheck
 } from 'lucide-react';
 
 const CmmcAssessmentStart = () => {


### PR DESCRIPTION
Add missing `Suspense`, `LoadingSpinner`, and `FileCheck` imports to fix runtime errors preventing access to assessment and other pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dc9bb12-1b69-4dbc-9933-5b0348f9e5f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dc9bb12-1b69-4dbc-9933-5b0348f9e5f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

